### PR TITLE
Use Pathname#read instead

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -7,7 +7,7 @@ module DatabaseRewinder
   class << self
     def init
       @cleaners, @table_names_cache, @clean_all, @only, @except = [], {}, false
-      @db_config = YAML::load(ERB.new(IO.read(Rails.root.join 'config/database.yml')).result)
+      @db_config = YAML::load(ERB.new(Rails.root.join('config/database.yml').read).result)
     end
 
     def create_cleaner(connection_name)


### PR DESCRIPTION
I think that `Pathname#read` can be used instead of using `IO#read` with `Pathname` instance...

Are there any reasons? 
