### PR TITLE
Create a version file.

### DIFF
--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -1,10 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'database_rewinder/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "database_rewinder"
-  spec.version       = '0.0.2'
+  spec.version       = DatabaseRewinder::VERSION
   spec.authors       = ["Akira Matsuda"]
   spec.email         = ["ronnie@dio.jp"]
   spec.description   = "A minimalist's tiny and ultra-fast database cleaner"

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -1,8 +1,9 @@
+require_relative 'database_rewinder/version'
 require_relative 'database_rewinder/cleaner'
 require_relative 'database_rewinder/railtie'
 
 module DatabaseRewinder
-  VERSION = Gem.loaded_specs['database_rewinder'].version.to_s
+  VERSION = DatabaseRewinder::VERSION
 
   class << self
     def init

--- a/lib/database_rewinder/version.rb
+++ b/lib/database_rewinder/version.rb
@@ -1,0 +1,3 @@
+module DatabaseRewinder
+  VERSION = "0.0.2"
+end


### PR DESCRIPTION
I clone and `bundle` and tried to run the spec but do not know why the `Gem.loaded_specs['database_rewinder']` is not working.

Some info:

``` bash
$ bundle show database_rewinder
/Users/Mac/dev/database_rewinder
$ rake spec
/Users/Mac/.rvm/rubies/ruby-2.0.0-p247/bin/ruby -S rspec ./spec/active_record_monkey_spec.rb ./spec/database_rewinder_spec.rb
/Users/Mac/dev/database_rewinder/lib/database_rewinder.rb:5:in `<module:DatabaseRewinder>': undefined method `version' for nil:NilClass (NoMethodError)
    from /Users/Mac/dev/database_rewinder/lib/database_rewinder.rb:4:in `<top (required)>'
    from /Users/Mac/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/Mac/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/Mac/dev/database_rewinder/spec/spec_helper.rb:7:in `<top (required)>'
    from /Users/Mac/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/Mac/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/Mac/dev/database_rewinder/spec/active_record_monkey_spec.rb:1:in `<top (required)>'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `load'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `each'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
    from /Users/Mac/.rvm/gems/ruby-2.0.0-p247@database_rewinder/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `block in autorun'
/Users/Mac/.rvm/rubies/ruby-2.0.0-p247/bin/ruby -S rspec ./spec/active_record_monkey_spec.rb ./spec/database_rewinder_spec.rb failed
```

So I propose create a `version.rb` file and load it like so in this Pull Request. :smiley: 
