### PR TITLE
Except schema_migtations from chached table names to prevent unexpected deletion

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -78,7 +78,7 @@ module DatabaseRewinder
     # cache AR connection.tables
     def all_table_names(connection)
       db = connection.instance_variable_get(:'@config')[:database]
-      @table_names_cache[db] ||= connection.tables
+      @table_names_cache[db] ||= connection.tables.reject{|t| t == 'schema_migrations' }
     end
   end
 end

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -36,4 +36,18 @@ describe DatabaseRewinder do
       Bar.count.should == 0
     end
   end
+
+  describe '.clean_all' do
+    before do
+      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::SchemaMigration.create! version: '001'
+      Foo.create! name: 'foo1'
+      DatabaseRewinder.clean_all
+    end
+    after { ActiveRecord::SchemaMigration.drop_table }
+    it 'should clean except schema_migrations' do
+      Foo.count.should == 0
+      ActiveRecord::SchemaMigration.count.should == 1
+    end
+  end
 end


### PR DESCRIPTION
Reproducing example:

``` ruby
RSpec.configure do |config|
  config.after :suite do
    DatabaseRewinder.clean_all
  end
end
```

Then running rspec will delete records even in schema_migrations.
