### PR TITLE
Use AR::Migrator.schema_migrations_table_name instead of hardcoding

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -79,7 +79,7 @@ module DatabaseRewinder
     # cache AR connection.tables
     def all_table_names(connection)
       db = connection.instance_variable_get(:'@config')[:database]
-      @table_names_cache[db] ||= connection.tables.reject{|t| t == 'schema_migrations' }
+      @table_names_cache[db] ||= connection.tables.reject{|t| t == ActiveRecord::Migrator.schema_migrations_table_name }
     end
   end
 end


### PR DESCRIPTION
to work correctly in case of using AR::Base.table_name_prefix/suffix
