### PR TITLE
Enable `.clean_with` to receive simple arguments

### DIFF
--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -27,9 +27,10 @@ module DatabaseRewinder
       reset
     end
 
-    def clean_with(_strategy, only: nil, except: nil, **)
+    def clean_with(*args)
+      options = args.extract_options!
       originals = @only, @except
-      @only, @except = Array(only), Array(except)
+      @only, @except = Array(options[:only]), Array(options[:except])
       clean_all
     ensure
       @only, @except = originals

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -66,24 +66,54 @@ describe DatabaseRewinder do
       @except = @cleaner.instance_variable_get(:@except)
       Foo.create! name: 'foo1'
       Bar.create! name: 'bar1'
-      DatabaseRewinder.clean_with :truncation, options
     end
 
-    context 'with only option' do
-      let(:options) { { only: ['foos'] } }
-      it 'should clean with only option and restore original one' do
-        Foo.count.should == 0
-        Bar.count.should == 1
-        expect(@cleaner.instance_variable_get(:@only)).to eq(@only)
+    context 'simple arguments' do
+      before do
+        DatabaseRewinder.clean_with options
+      end
+
+      context 'with only option' do
+        let(:options) { { only: ['foos'] } }
+        it 'should clean with only option and restore original one' do
+          Foo.count.should == 0
+          Bar.count.should == 1
+          expect(@cleaner.instance_variable_get(:@only)).to eq(@only)
+        end
+      end
+
+      context 'with except option' do
+        let(:options) { { except: ['bars'] } }
+        it 'should clean with except option and restore original one' do
+          Foo.count.should == 0
+          Bar.count.should == 1
+          expect(@cleaner.instance_variable_get(:@except)).to eq(@except)
+        end
       end
     end
 
-    context 'with except option' do
-      let(:options) { { except: ['bars'] } }
-      it 'should clean with except option and restore original one' do
-        Foo.count.should == 0
-        Bar.count.should == 1
-        expect(@cleaner.instance_variable_get(:@except)).to eq(@except)
+
+    context 'compatible arguments' do
+      before do
+        DatabaseRewinder.clean_with :truncation, options
+      end
+
+      context 'with only option' do
+        let(:options) { { only: ['foos'] } }
+        it 'should clean with only option and restore original one' do
+          Foo.count.should == 0
+          Bar.count.should == 1
+          expect(@cleaner.instance_variable_get(:@only)).to eq(@only)
+        end
+      end
+
+      context 'with except option' do
+        let(:options) { { except: ['bars'] } }
+        it 'should clean with except option and restore original one' do
+          Foo.count.should == 0
+          Bar.count.should == 1
+          expect(@cleaner.instance_variable_get(:@except)).to eq(@except)
+        end
       end
     end
   end


### PR DESCRIPTION
This change enables the method to receive as the following

``` ruby
DatabaseRewinder.clean_with except: ["foos"]
```

while keeping compatibility.

``` ruby
DatabaseRewinder.clean_with :truncation, except: ["foos"]
```

for DatabaseRewinder first-choice users :dash:
