### PR TITLE
[FIX] Database adapters may not be loaded

### DIFF
--- a/lib/database_rewinder/active_record_monkey.rb
+++ b/lib/database_rewinder/active_record_monkey.rb
@@ -12,6 +12,18 @@ module DatabaseRewinder
   end
 end
 
-::ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :prepend, DatabaseRewinder::InsertRecorder if defined? ::ActiveRecord::ConnectionAdapters::SQLite3Adapter
-::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :prepend, DatabaseRewinder::InsertRecorder if defined? ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.send :prepend, DatabaseRewinder::InsertRecorder if defined? ::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
+begin
+  require 'active_record/connection_adapters/sqlite3_adapter'
+  ::ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :prepend, DatabaseRewinder::InsertRecorder
+rescue LoadError
+end
+begin
+  require 'active_record/connection_adapters/postgresql_adapter'
+  ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :prepend, DatabaseRewinder::InsertRecorder
+rescue LoadError
+end
+begin
+  require 'active_record/connection_adapters/abstract_mysql_adapter'
+  ::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.send :prepend, DatabaseRewinder::InsertRecorder
+rescue LoadError
+end


### PR DESCRIPTION
Any database adapters may not be loaded before database_rewinder, checking class existence by "defined?" expression does not work.  In my case, PostgreSQLAdapter is not loaded and it's queries were not recorded.
