### PR TITLE
Support table_name with database name

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -47,8 +47,10 @@ module DatabaseRewinder
         end
       end or return
 
-      match = sql.match(/\AINSERT INTO [`"]?([^\s`"]+)[`"]?/i)
-      table = match[1] if match
+      match = sql.match(/\AINSERT INTO [`"]?([^\s`"]+)[`"]?(?:\.[`"]?([^\s`"]+)[`"]?)?/i)
+      return unless match
+
+      table = match[2] || match[1]
       if table
         cleaner.inserted_tables << table unless cleaner.inserted_tables.include? table
         cleaner.pool ||= connection.pool

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -23,14 +23,22 @@ describe DatabaseRewinder do
       @cleaner = DatabaseRewinder.create_cleaner 'foo'
       connection = double('connection').as_null_object
       connection.instance_variable_set :'@config', {adapter: 'sqlite3', database: File.expand_path('db/test.sqlite3', Rails.root) }
-      DatabaseRewinder.record_inserted_table(connection, 'INSERT INTO "foos" ("name") VALUES (?)')
+      DatabaseRewinder.record_inserted_table(connection, sql)
     end
     after do
       DatabaseRewinder.database_configuration = nil
     end
     subject { @cleaner }
 
-    its(:inserted_tables) { should == ['foos'] }
+    context 'include database name' do
+      let(:sql) { 'INSERT INTO "database"."foos" ("name") VALUES (?)' }
+      its(:inserted_tables) { should == ['foos'] }
+    end
+
+    context 'only table name' do
+      let(:sql) { 'INSERT INTO "foos" ("name") VALUES (?)' }
+      its(:inserted_tables) { should == ['foos'] }
+    end
   end
 
   describe '.clean' do


### PR DESCRIPTION
When the table name of an ActiveRecord class is set explicitly, and if the table name contains the database name, database_rewinder fails to clear that table. 

This PR fix the issue.

If I created user model like this.

```
class User < ActiveRecord::Base
  self.table_name = 'my_database.user'
end
```

INSERT SQL is following.

```
INSERT INTO `my_database`.`user` (`created_at`, `updated_at`) VALUES ('2015-01-22 05:57:42', '2015-01-22 05:57:42')
```

[INSERT SQL regular expression](https://github.com/amatsuda/database_rewinder/blob/5210f241194d8bb894b935782c1724a8bbcb4707/lib/database_rewinder.rb#L50) matches 'my_database'

So, I changes INSERT SQL regular expression like [this](https://github.com/ppworks/database_rewinder/blob/5a9162d070e89451b966c97bc2ed7715412a20f6/lib/database_rewinder.rb#L50).
