### PR TITLE
Compare database config with include? instead of expanding path

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -57,7 +57,7 @@ module DatabaseRewinder
       match = sql.match(/\AINSERT INTO (?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
 
       return unless match && table = match[1]
-      cleaner.inserted_tables << table unless cleaner.inserted_tables.include? table
+      cleaner.add_table(table.downcase)
       cleaner.pool ||= connection.pool
     end
 

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -52,25 +52,13 @@ module DatabaseRewinder
 
     def record_inserted_table(connection, sql)
       config = connection.instance_variable_get(:'@config')
-      database = config[:database]
-      #NOTE What's the best way to get the app dir besides Rails.root? I know Dir.pwd here might not be the right solution, but it should work in most cases...
-      root_dir = defined?(Rails) ? Rails.root : Dir.pwd
-      cleaner = cleaners.detect do |c|
-        if (config[:adapter] == 'sqlite3') && (config[:database] != ':memory:')
-          File.expand_path(c.db, root_dir) == File.expand_path(database, root_dir)
-        else
-          c.db == database
-        end
-      end or return
+      cleaner = cleaners.detect {|c| config[:database] =~ %r(#{c.db}$)} or return
 
       match = sql.match(/\AINSERT INTO (?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
-      return unless match
 
-      table = match[1]
-      if table
-        cleaner.inserted_tables << table unless cleaner.inserted_tables.include? table
-        cleaner.pool ||= connection.pool
-      end
+      return unless match && table = match[1]
+      cleaner.inserted_tables << table unless cleaner.inserted_tables.include? table
+      cleaner.pool ||= connection.pool
     end
 
     def clean

--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -11,6 +11,10 @@ module DatabaseRewinder
       config['database']
     end
 
+    def add_table(table)
+      @inserted_tables << table unless @inserted_tables.include? table
+    end
+
     def clean
       return if !pool || inserted_tables.empty?
 

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -55,42 +55,65 @@ describe DatabaseRewinder do
   end
 
   describe '.record_inserted_table' do
-    before do
-      DatabaseRewinder.database_configuration = {'foo' => {'adapter' => 'sqlite3', 'database' => 'db/test_record_inserted_table.sqlite3'}}
-      @cleaner = DatabaseRewinder.create_cleaner 'foo'
-      connection = double('connection').as_null_object
-      connection.instance_variable_set :'@config', {adapter: 'sqlite3', database: File.expand_path('db/test_record_inserted_table.sqlite3', Rails.root) }
-      DatabaseRewinder.record_inserted_table(connection, sql)
+    let(:connection) do
+      double('connection').as_null_object.tap do |conn|
+        conn.instance_variable_set :'@config', {adapter: 'sqlite3', database: database}
+      end
     end
+
     after do
       DatabaseRewinder.database_configuration = nil
     end
-    subject { @cleaner }
 
-    context 'common database' do
-      context 'include database name' do
-        let(:sql) { 'INSERT INTO "database"."foos" ("name") VALUES (?)' }
-        its(:inserted_tables) { should == ['foos'] }
+    context 'one database' do
+      before do
+        DatabaseRewinder.database_configuration = {'foo' => {'adapter' => 'sqlite3', 'database' => 'db/test_record_inserted_table.sqlite3'}}
+        @cleaner = DatabaseRewinder.create_cleaner 'foo'
+        DatabaseRewinder.record_inserted_table(connection, sql)
       end
-      context 'only table name' do
-        let(:sql) { 'INSERT INTO "foos" ("name") VALUES (?)' }
-        its(:inserted_tables) { should == ['foos'] }
+      let(:database) { File.expand_path('db/test_record_inserted_table.sqlite3', Rails.root) }
+      subject { @cleaner }
+
+      context 'common database' do
+        context 'include database name' do
+          let(:sql) { 'INSERT INTO "database"."foos" ("name") VALUES (?)' }
+          its(:inserted_tables) { should == ['foos'] }
+        end
+        context 'only table name' do
+          let(:sql) { 'INSERT INTO "foos" ("name") VALUES (?)' }
+          its(:inserted_tables) { should == ['foos'] }
+        end
+      end
+
+      context 'Database accepts more than one dots in an object notation(exp: SQLServer)' do
+        context 'full joined' do
+          let(:sql) { 'INSERT INTO server.database.schema.foos ("name") VALUES (?)' }
+          its(:inserted_tables) { should == ['foos'] }
+        end
+        context 'missing one' do
+          let(:sql) { 'INSERT INTO database..foos ("name") VALUES (?)' }
+          its(:inserted_tables) { should == ['foos'] }
+        end
+
+        context 'missing two' do
+          let(:sql) { 'INSERT INTO server...foos ("name") VALUES (?)' }
+          its(:inserted_tables) { should == ['foos'] }
+        end
       end
     end
 
-    context 'Database accepts more than one dots in an object notation(exp: SQLServer)' do
-      context 'full joined' do
-        let(:sql) { 'INSERT INTO server.database.schema.foos ("name") VALUES (?)' }
-        its(:inserted_tables) { should == ['foos'] }
+    context 'multiple databases' do
+      before do
+        DatabaseRewinder.database_configuration = {'foo' => {'database' => 'foo'}, 'foobar' => {'database' => 'foobar'}}
       end
-      context 'missing one' do
-        let(:sql) { 'INSERT INTO database..foos ("name") VALUES (?)' }
-        its(:inserted_tables) { should == ['foos'] }
-      end
+      let(:database) { 'foo' }
+      let!(:foobar)  { DatabaseRewinder.create_cleaner 'foobar' }
+      let!(:foo)     { DatabaseRewinder.create_cleaner 'foo' }
 
-      context 'missing two' do
-        let(:sql) { 'INSERT INTO server...foos ("name") VALUES (?)' }
-        its(:inserted_tables) { should == ['foos'] }
+      it 'does not add tables to the wrong database' do
+        DatabaseRewinder.record_inserted_table(connection, 'INSERT INTO "something" ("name") VALUES (?)')
+        expect(foo.inserted_tables).to eq(['something'])
+        expect(foobar.inserted_tables).to be_empty
       end
     end
   end

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -83,6 +83,10 @@ describe DatabaseRewinder do
           let(:sql) { 'INSERT INTO "foos" ("name") VALUES (?)' }
           its(:inserted_tables) { should == ['foos'] }
         end
+        context 'capitalized table name' do
+          let(:sql) { 'INSERT INTO "FOOS" ("name") VALUES (?)' }
+          its(:inserted_tables) { should == ['foos'] }
+        end
       end
 
       context 'Database accepts more than one dots in an object notation(exp: SQLServer)' do


### PR DESCRIPTION
I use Firebird database (not by preference). It works similarly to sqlite3 in that it creates database files.

Because of the explicit check for sqlite3, I was having some trouble. Instead of expanding the path to the database, I figure you could probably just check if the expanded file path includes the un-expanded path.

The other change I made downcases matched table names. The firebird adapter capitalizes table names, so the merge in `Cleaner#clean` was returning an empty array. I think all of the supported adapters return table names in lower case, anyway. This would save you if you explicitly used `connection.execute 'INSERT INTO TABLE'`
