### PR TITLE
Pause functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ RSpec.configure do |config|
 end
 ```
 
+### Pausing DatabaseRewinder
+
+Do 'pause' before creating data to have DatabaseRewinder temporarily skip cleaning. Do 'resume' afterwards to
+resume the normal DatabaseRewinder behavior. These methods assume 'clean' or 'clean_all' is being called after every test.
+If not, run 'clean' or 'clean_all' manually after 'resume'
+
+```ruby
+DatabaseRewinder.pause
+Foo.create! name: 'foo1'
+Bar.create! name: 'bar1'
+DatabaseRewinder.clean
+# 'foo1' and 'bar1' will still exist
+DatabaseRewinder.resume
+DatabaseRewinder.clean
+# 'foo1' and 'bar1' will be cleaned
+```
+
 ### Dealing with multiple DBs
 
 You can configure multiple DB connections to tell DatabaseRewinder to cleanup all of them after each test.

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -87,6 +87,9 @@ module DatabaseRewinder
       cleaners.each(&:clean_all)
     end
 
+    # Pause and Resume are meant to be called whenever DatabaseRewinder should not clean between tests.
+    # These methods assume that DatabaseRewinder is being called after every test run.
+    # If not being called in a before block of any kind, .clean or .clean_all must be called after .resume
     def pause
       @pause = true
     end

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -74,6 +74,7 @@ module DatabaseRewinder
     end
 
     def clean
+      return if @pause
       if @clean_all
         clean_all
       else
@@ -82,7 +83,16 @@ module DatabaseRewinder
     end
 
     def clean_all
+      return if @pause
       cleaners.each(&:clean_all)
+    end
+
+    def pause
+      @pause = true
+    end
+
+    def resume
+      @pause = false
     end
 
     # cache AR connection.tables

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -10,7 +10,7 @@ describe DatabaseRewinder do
       after do
         DatabaseRewinder.database_configuration = nil
       end
-      subject { DatabaseRewinder.instance_variable_get(:'@cleaners').map {|c| c.connection_name} }
+      subject { DatabaseRewinder.instance_variable_get(:'@cleaners').map { |c| c.connection_name } }
 
       context 'simply giving a connection name only' do
         before do
@@ -59,7 +59,7 @@ describe DatabaseRewinder do
       DatabaseRewinder.database_configuration = {'foo' => {'adapter' => 'sqlite3', 'database' => 'db/test_record_inserted_table.sqlite3'}}
       @cleaner = DatabaseRewinder.create_cleaner 'foo'
       connection = double('connection').as_null_object
-      connection.instance_variable_set :'@config', {adapter: 'sqlite3', database: File.expand_path('db/test_record_inserted_table.sqlite3', Rails.root) }
+      connection.instance_variable_set :'@config', {adapter: 'sqlite3', database: File.expand_path('db/test_record_inserted_table.sqlite3', Rails.root)}
       DatabaseRewinder.record_inserted_table(connection, sql)
     end
     after do
@@ -132,7 +132,7 @@ describe DatabaseRewinder do
     end
 
     context 'with only option' do
-      let(:options) { { only: ['foos'] } }
+      let(:options) { {only: ['foos']} }
       it 'should clean with only option and restore original one' do
         Foo.count.should == 0
         Bar.count.should == 1
@@ -141,7 +141,7 @@ describe DatabaseRewinder do
     end
 
     context 'with except option' do
-      let(:options) { { except: ['bars'] } }
+      let(:options) { {except: ['bars']} }
       it 'should clean with except option and restore original one' do
         Foo.count.should == 0
         Bar.count.should == 1
@@ -153,7 +153,7 @@ describe DatabaseRewinder do
   describe '.strategy=' do
     context 'call first with options' do
       before do
-        DatabaseRewinder.strategy = :truncate, { only: ['foos'], except: ['bars'] }
+        DatabaseRewinder.strategy = :truncate, {only: ['foos'], except: ['bars']}
       end
 
       it 'should set options' do
@@ -169,7 +169,7 @@ describe DatabaseRewinder do
 
       context 'call again with different options' do
         before do
-          DatabaseRewinder.strategy = :truncate, { only: ['bazs'], except: [] }
+          DatabaseRewinder.strategy = :truncate, {only: ['bazs'], except: []}
         end
 
         it 'should overwrite options' do
@@ -183,6 +183,31 @@ describe DatabaseRewinder do
           expect(cleaner.instance_variable_get(:@except)).to eq([])
         end
       end
+    end
+  end
+
+  describe '.pause' do
+
+    it 'should not clean initially' do
+      DatabaseRewinder.pause
+      Foo.create! name: 'foo1'
+      Bar.create! name: 'bar1'
+      DatabaseRewinder.clean
+      Foo.count.should == 1
+      Bar.count.should == 1
+    end
+
+    it 'should clean after calling .resume' do
+      DatabaseRewinder.pause
+      Foo.create! name: 'foo1'
+      Bar.create! name: 'bar1'
+      DatabaseRewinder.clean
+      Foo.count.should == 1
+      Bar.count.should == 1
+      DatabaseRewinder.resume
+      DatabaseRewinder.clean
+      Foo.count.should == 0
+      Bar.count.should == 0
     end
   end
 end


### PR DESCRIPTION
This should hopefully be a simple addition to DatabaseRewinder. I've made it so that a 'pause' method is available to skip cleaning for an arbitrary amount of time, and a 'resume' method is available to resume cleaning as normal. 

I use DatabaseRewinder at work, and I've had a few feature cases where having such a function would be great (IE: Feature tests, especially using JS).
