### PR TITLE
Fix regexp for INSERT IGNORE INTO statement

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -63,7 +63,7 @@ module DatabaseRewinder
         end
       end or return
 
-      match = sql.match(/\AINSERT INTO (?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
+      match = sql.match(/\AINSERT(?: IGNORE)? INTO (?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
       return unless match
 
       table = match[1]

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -93,6 +93,11 @@ describe DatabaseRewinder do
         its(:inserted_tables) { should == ['foos'] }
       end
     end
+
+    context 'when database accepts INSERT IGNORE INTO statement' do
+      let(:sql) { "INSERT IGNORE INTO `foos` (`name`) VALUES ('alice'), ('bob') ON DUPLICATE KEY UPDATE `foos`.`updated_at`=VALUES(`updated_at`)" }
+      its(:inserted_tables) { should == ['foos'] }
+    end
   end
 
   describe '.clean' do


### PR DESCRIPTION
Such query is issued from `Foo.import(foos, ignore: true)` with
activerecord-import gem.