### PR TITLE
Add cleaning method 

### DIFF
--- a/lib/database_rewinder/compatibility.rb
+++ b/lib/database_rewinder/compatibility.rb
@@ -4,6 +4,16 @@ module DatabaseRewinder
       cleaners.each {|c| c.clean_with(*args)}
     end
 
+    def cleaning(&block)
+      begin
+        yield
+      ensure
+        cleaners.each do |cleaner|
+          cleaner.clean_all
+        end
+      end
+    end
+
     def start; end
 
     def strategy=(args)

--- a/spec/database_rewinder_spec.rb
+++ b/spec/database_rewinder_spec.rb
@@ -157,6 +157,31 @@ describe DatabaseRewinder do
     end
   end
 
+  describe '.cleaning' do
+    context 'without exception' do
+      before do
+        DatabaseRewinder.cleaning do
+          Foo.create! name: 'foo1'
+        end
+      end
+
+      it 'should clean' do
+        expect(Foo.count).to be_zero
+      end
+    end
+
+    context 'with exception' do
+      it 'should clean regardless of exception' do
+        expect {
+          DatabaseRewinder.cleaning do
+            Foo.create! name: 'foo1'; fail
+          end
+        }.to raise_error
+        expect(Foo.count).to be_zero
+      end
+    end
+  end
+
   describe '.strategy=' do
     context 'call first with options' do
       before do


### PR DESCRIPTION
This pull request is a feature implement.
I added clearing method.
The reason for the added is simple. database_cleaner have a cleaning method.
so We have to make DatabaseRewinder be compatible with DatabaseCleaner. 
because DatabaseCleaner class should be replaceable to DatabaseRewinder. [FYI](https://github.com/amatsuda/database_rewinder#pro-tip)

So I added claering method, wrote a test for clearing method and I tested on my product.

## Testing
My DatabaseRewinder's configurations is

```ruby
RSpec.configure do |config|
  config.before(:suite) do
    DatabaseRewinder.clean_with(:truncation, except: %w(languages))
    DatabaseRewinder.strategy = :transaction
  end

  config.around(:each) do |example|
    DatabaseRewinder.cleaning do
      example.run
    end
  end
end
```

So I executed `rspec spec` on my product then output this:

<img width="958" alt="screenshot 2016-04-14 22 52 19" src="https://cloud.githubusercontent.com/assets/3052342/14532195/2f7ee28a-029b-11e6-934c-4dfcf90a65e6.png">

👯  It was successfully executed.