### PR TITLE
DatabaseRewinder should not delete internal metadata table

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -73,7 +73,10 @@ module DatabaseRewinder
     def all_table_names(connection)
       db = connection.pool.spec.config[:database]
       data_sources = connection.respond_to?(:data_sources) ? connection.data_sources : connection.tables
-      @table_names_cache[db] ||= data_sources.reject {|t| t == ActiveRecord::Migrator.schema_migrations_table_name }
+      @table_names_cache[db] ||= data_sources.reject do |t|
+        t == ActiveRecord::Migrator.schema_migrations_table_name ||
+        ActiveRecord::Base.respond_to?(:internal_metadata_table_name) && t == ActiveRecord::Base.internal_metadata_table_name
+      end
     end
   end
 end


### PR DESCRIPTION
This commit fixes the following error in Rails 5.0.

```
$ bundle exec rspec spec # DatabaseRewinder deletes the internal metadata table
------
DELETE FROM `ar_internal_metadata`;
------
$ RAILS_ENV=test bundle exec rake db:migrate reset
rake aborted!
ActiveRecord::NoEnvironmentInSchemaError:

Environment data not found in the schema. To resolve this issue, run:

        bin/rails db:environment:set RAILS_ENV=test

Tasks: TOP => db:migrate:reset => db:drop => db:check_protected_environments
(See full trace by running task with --trace)
```