### PR TITLE
Use database configuration itself as a cache key

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -71,10 +71,10 @@ module DatabaseRewinder
 
     # cache AR connection.tables
     def all_table_names(connection)
-      db = connection.pool.spec.config[:database]
+      cache_key = connection.pool.spec.config
       #NOTE connection.tables warns on AR 5 with some adapters
       tables = ActiveSupport::Deprecation.silence { connection.tables }
-      @table_names_cache[db] ||= tables.reject do |t|
+      @table_names_cache[cache_key] ||= tables.reject do |t|
         (t == ActiveRecord::Migrator.schema_migrations_table_name) ||
         (ActiveRecord::Base.respond_to?(:internal_metadata_table_name) && (t == ActiveRecord::Base.internal_metadata_table_name))
       end


### PR DESCRIPTION
When there's multiple DB entries with the same database name, table
names are cached wrongly.

```yaml
test:
  adapter: mysql2
  database: rewinder_test
test_pg:
  adapter: postgresql
  database: rewinder_test
```