### PR TITLE
Add disable FOREIGN_KEY_CHECK statement

### DIFF
--- a/lib/database_rewinder/multiple_statements_executor.rb
+++ b/lib/database_rewinder/multiple_statements_executor.rb
@@ -25,6 +25,7 @@ module DatabaseRewinder
             # opens another connection to the DB
             client = Mysql2::Client.new query_options
             begin
+              client.query("SET FOREIGN_KEY_CHECKS = 0")
               _result = log(sql) { client.query sql }
               while client.next_result
                 # just to make sure that all queries are finished


### PR DESCRIPTION
If MySQL2::Client::MULTI_STATEMENTS is off, this gem creates new connection.
Because of it, FOREIGN_KEY_CHECK is enabled again.