### PR TITLE
Fix markup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You would occasionally hit some weird errors (e.g. query execution timeout) beca
 
 #### 1. Properly understand what `use_transactional_tests` means, and consider turning it off
 
-`use\_transactional\_tests` is the option that surrounds each of your test case with a DB transaction to roll back all your test data after each test run.
+`use_transactional_tests` is the option that surrounds each of your test case with a DB transaction to roll back all your test data after each test run.
 So far as this works properly, you won't really need to use database\_rewinder.
 However, this simple mechanism doesn't work well when you're running integration tests with capybara + js mode.
 In cases of this situation, bundle database\_rewinder and add the following configuration.


### PR DESCRIPTION
The escape string is unnecessary inside backquote.

Before:
![2016-12-07 15 08 57](https://cloud.githubusercontent.com/assets/290782/20956741/28f1f6ec-bc8f-11e6-8ea7-6a819c8e50d0.png)


After:
![2016-12-07 15 08 47](https://cloud.githubusercontent.com/assets/290782/20956735/271e0874-bc8f-11e6-9ad6-82020b26fd0d.png)
