### PR TITLE
Allow space before insert statement

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -48,7 +48,7 @@ module DatabaseRewinder
         end
       end or return
 
-      match = sql.match(/\AINSERT(?:\s+IGNORE)?(?:\s+INTO)?\s+(?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
+      match = sql.match(/\A\s*INSERT(?:\s+IGNORE)?(?:\s+INTO)?\s+(?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
       return unless match
 
       table = match[1]

--- a/test/database_rewinder_test.rb
+++ b/test/database_rewinder_test.rb
@@ -88,6 +88,12 @@ class DatabaseRewinder::DatabaseRewinderTest < ActiveSupport::TestCase
         perform_insert 'INSERT "foos" ("name") VALUES (?)'
         assert_equal ['foos'], @cleaner.inserted_tables
       end
+      test 'with space before "INSERT"' do
+        perform_insert <<-SQL
+          INSERT INTO "foos" ("name") VALUES (?)
+        SQL
+        assert_equal ['foos'], @cleaner.inserted_tables
+      end
     end
 
     sub_test_case 'Database accepts more than one dots in an object notation (e.g. SQLServer)' do


### PR DESCRIPTION
This PR allow space before `INSERT` which can occur when using here doc.

```ruby

query = <<-SQL
  INSERT INTO foos ("name")
  VALUES ("bar")
SQL

ActiveRecord::Base.connection.execute(query)
```