### PR TITLE
Strict rails checking

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -39,7 +39,7 @@ module DatabaseRewinder
       config = connection.instance_variable_get(:'@config')
       database = config[:database]
       #NOTE What's the best way to get the app dir besides Rails.root? I know Dir.pwd here might not be the right solution, but it should work in most cases...
-      root_dir = defined?(Rails) ? Rails.root : Dir.pwd
+      root_dir = defined?(Rails) && Rails.respond_to?(:root) ? Rails.root : Dir.pwd
       cleaner = cleaners.detect do |c|
         if (config[:adapter] == 'sqlite3') && (config[:database] != ':memory:')
           File.expand_path(c.db, root_dir) == File.expand_path(database, root_dir)


### PR DESCRIPTION
# Why 
When using `database_rewinder` with `sinatra` and `kaminari-sinatra`,  `database_rewinder` misunderstands Rails app (Despite being not a Rails app :astonished:)

# Example
## Gemfile

```ruby
gem "sinatra", "2.0.0"
gem "kaminari-sinatra", "1.0.1"

group :test do
  gem "database_rewinder", "0.8.1"
end
```

## spec_helper.rb
```ruby
RSpec.configure do |config|
  config.before(:suite) do
    DatabaseRewinder.clean_all
    # or
    # DatabaseRewinder.clean_with :any_arg_that_would_be_actually_ignored_anyway
  end

  config.after(:each) do
    DatabaseRewinder.clean
  end
end
```

## running spec
```sh
$ bundle exec rspec

Randomized with seed 15399

An error occurred in a `before(:suite)` hook.
Failure/Error: DatabaseRewinder.clean_all

NoMethodError:
  undefined method `root' for Rails:Module
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder.rb:42:in `record_inserted_table'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder/active_record_monkey.rb:10:in `exec_query'
# ./vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:69:in `select_rows'
# ./vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:63:in `select_values'
# ./vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:266:in `data_sources'
# ./vendor/bundle/ruby/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:262:in `tables'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder.rb:77:in `block in all_table_names'
# ./vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.2/lib/active_support/deprecation/reporting.rb:36:in `silence'
# ./vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.2/lib/active_support/deprecation/instance_delegator.rb:20:in `silence'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder.rb:77:in `all_table_names'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder/cleaner.rb:39:in `block in clean_all'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder/dummy_model.rb:7:in `with_temporary_connection'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder/cleaner.rb:38:in `clean_all'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder.rb:70:in `block in clean_all'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder.rb:70:in `each'
# ./vendor/bundle/ruby/2.4.0/gems/database_rewinder-0.8.0/lib/database_rewinder.rb:70:in `clean_all'
# ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'
```

## Why?
`rails-html-sanitizer` (deep dependency of  `kaminari-sinatra` ) defines `Rails` module

https://github.com/rails/rails-html-sanitizer/blob/v1.0.3/lib/rails-html-sanitizer.rb#L6

### Gemfile.lock

```ruby
Gem
  specs:
    kaminari-sinatra (1.0.1)
      actionview
      kaminari-core (~> 1.0)
      padrino-helpers
      sinatra

    actionview (5.1.1)
      activesupport (= 5.1.1)
      builder (~> 3.1)
      erubi (~> 1.4)
      rails-dom-testing (~> 2.0)
      rails-html-sanitizer (~> 1.0, >= 1.0.3)

```

