### PR TITLE
Use use_transactional_tests instead of use_transactional_examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In cases of this situation, bundle database\_rewinder and add the following conf
 
 ```ruby
 RSpec.configure do |config|
-  config.use_transactional_examples = false
+  config.use_transactional_tests = false
 
   ...
 end


### PR DESCRIPTION
I think that `use_transactional_tests` is more correct than `use_transactional_examples` in this context. 