### PR TITLE
Add support for multi-statement query

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -48,13 +48,15 @@ module DatabaseRewinder
         end
       end or return
 
-      match = sql.match(/\A\s*INSERT(?:\s+IGNORE)?(?:\s+INTO)?\s+(?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
-      return unless match
+      sql.split(';').each do |statement|
+        match = statement.match(/\A\s*INSERT(?:\s+IGNORE)?(?:\s+INTO)?\s+(?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
+        next unless match
 
-      table = match[1]
-      if table
-        cleaner.inserted_tables << table unless cleaner.inserted_tables.include? table
-        cleaner.pool ||= connection.pool
+        table = match[1]
+        if table
+          cleaner.inserted_tables << table unless cleaner.inserted_tables.include? table
+          cleaner.pool ||= connection.pool
+        end
       end
     end
 

--- a/test/database_rewinder_test.rb
+++ b/test/database_rewinder_test.rb
@@ -94,6 +94,14 @@ class DatabaseRewinder::DatabaseRewinderTest < ActiveSupport::TestCase
         SQL
         assert_equal ['foos'], @cleaner.inserted_tables
       end
+
+      test 'with multi statement query' do
+        perform_insert <<-SQL
+          INSERT INTO "foos" ("name") VALUES (?);
+          INSERT INTO "bars" ("name") VALUES (?)
+        SQL
+        assert_equal ['foos', 'bars'], @cleaner.inserted_tables
+      end
     end
 
     sub_test_case 'Database accepts more than one dots in an object notation (e.g. SQLServer)' do


### PR DESCRIPTION
Since Rails 5.2, fixtures use multi-statement query when inserting.
https://github.com/rails/rails/pull/31422

However, since `database_rewinder` does not support multi-statement query, tables inserted by fixture is not cleaned.
This patch also adds support to allow to retrieve the table where insert was done even if a query is multi-statement.