### PR TITLE
Update cache_key for rails 6.1

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -73,7 +73,7 @@ module DatabaseRewinder
 
     # cache AR connection.tables
     def all_table_names(connection)
-      cache_key = connection.pool.spec.config
+      cache_key = get_cache_key(connection.pool)
       #NOTE connection.tables warns on AR 5 with some adapters
       tables = ActiveSupport::Deprecation.silence { connection.tables }
       @table_names_cache[cache_key] ||= tables.reject do |t|
@@ -81,7 +81,17 @@ module DatabaseRewinder
         (ActiveRecord::Base.respond_to?(:internal_metadata_table_name) && (t == ActiveRecord::Base.internal_metadata_table_name))
       end
     end
+
+    def get_cache_key(connection_pool)
+      if connection_pool.respond_to?(:db_config) # ActiveRecord >= 6.1
+        connection_pool.db_config.config
+      else
+        connection_pool.spec.config
+      end
+    end
   end
+
+  private_class_method :get_cache_key
 end
 
 begin


### PR DESCRIPTION
The connection pool got refactored in https://github.com/rails/rails/pull/37253 and released in Rails 6.1.0.alpha (I‘m running rails master on my side project).

This Pull Request adds support for Rails 6.1.