### PR TITLE
Fix an issue recording table names to wrong cleaner

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -37,13 +37,14 @@ module DatabaseRewinder
     def record_inserted_table(connection, sql)
       config = connection.instance_variable_get(:'@config')
       database = config[:database]
+      host = config[:host]
       #NOTE What's the best way to get the app dir besides Rails.root? I know Dir.pwd here might not be the right solution, but it should work in most cases...
       root_dir = defined?(Rails) && Rails.respond_to?(:root) ? Rails.root : Dir.pwd
       cleaner = cleaners.detect do |c|
         if (config[:adapter] == 'sqlite3') && (config[:database] != ':memory:')
           File.expand_path(c.db, root_dir) == File.expand_path(database, root_dir)
         else
-          c.db == database
+          c.db == database && c.host == host
         end
       end or return
 

--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -17,6 +17,10 @@ module DatabaseRewinder
       config['database']
     end
 
+    def host
+      config['host']
+    end
+
     def clean(multiple: true)
       return if !pool || inserted_tables.empty?
 


### PR DESCRIPTION
DatabaesRewinder finds the wrong cleaner when using the same database name on different hosts.

It occurs with the following database.yml.

```yaml
default: &default
  adapter: postgresql
  encoding: unicode
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  username: postgres

test:
  primary:
    <<: *default
    host: main-db
    database: foo_test
  animals:
    <<: *default
    host: sub-db
    database: foo_test
    migrations_paths: db/animals_migrate
```