### PR TITLE
Update retrieving database config hash for Rails >= 6.1

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -86,7 +86,7 @@ module DatabaseRewinder
       if Gem::Version.new(Rails.version) >= Gem::Version.new("6.0.0")
         database_configuration.configs_for(env_name: connection_name).first.configuration_hash
       else
-        database_configuration["connection_name"]
+        database_configuration[connection_name]
       end
     end
 

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -83,7 +83,7 @@ module DatabaseRewinder
     end
 
     def get_config_from(connection_name)
-      if Gem::Version.new(Rails.version) >= Gem::Version.new("6.1.0.alpha")
+      if Gem::Version.new(Rails.version) >= Gem::Version.new("6.0.0")
         database_configuration.configs_for(env_name: connection_name).first.configuration_hash
       else
         database_configuration["connection_name"]
@@ -92,7 +92,7 @@ module DatabaseRewinder
 
     def get_cache_key(connection_pool)
       if connection_pool.respond_to?(:db_config) # ActiveRecord >= 6.1
-        if Gem::Version.new(Rails.version) >= Gem::Version.new("6.1.0.alpha")
+        if Gem::Version.new(Rails.version) >= Gem::Version.new("6.0.0")
           connection_pool.db_config.configuration_hash
         else
           connection_pool.db_config.config

--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -14,7 +14,7 @@ module DatabaseRewinder
     end
 
     def db
-      config['database']
+      config.fetch('database') { config[:database] }
     end
 
     def clean(multiple: true)


### PR DESCRIPTION
Somehow I missed this one in #67. Changed the way to retrieve the database config hash because the old way will stop working in Rails 6.2.

```diff
- database_configuration["connection_name"]
+ database_configuration.configs_for(env_name: "test").configuration_hash
```

This PR fixes following warnings:

```
DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2
(Use configs_for) (called from create_cleaner at
lib/database_rewinder.rb:19)

DEPRECATION WARNING: DatabaseConfig#config will be removed in 6.2.0 in
favor of DatabaseConfigurations#configuration_hash which returns a hash
with symbol keys (called from get_cache_key at
lib/database_rewinder.rb:87)
```

@eileencodes Does this look good to you? Thanks! 