### PR TITLE
Handle keyword arguments separately

### DIFF
--- a/lib/database_rewinder/active_record_monkey.rb
+++ b/lib/database_rewinder/active_record_monkey.rb
@@ -7,9 +7,16 @@ module DatabaseRewinder
       super
     end
 
-    def exec_query(sql, *)
-      DatabaseRewinder.record_inserted_table self, sql
-      super
+    if Rails::VERSION::MAJOR < 5
+      def exec_query(sql, *)
+        DatabaseRewinder.record_inserted_table self, sql
+        super
+      end
+    else
+      def exec_query(sql, *, **)
+        DatabaseRewinder.record_inserted_table self, sql
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, amatsuda

I got this warning on ruby 2.7.x and want to remove it.
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

If the patch is no problem, could you please merge them?

Thanks.