### PR TITLE
Fix LoadError without Rails

### DIFF
--- a/lib/database_rewinder/active_record_monkey.rb
+++ b/lib/database_rewinder/active_record_monkey.rb
@@ -7,7 +7,7 @@ module DatabaseRewinder
       super
     end
 
-    if Rails::VERSION::MAJOR < 5
+    if ActiveRecord::VERSION::MAJOR < 5
       def exec_query(sql, *)
         DatabaseRewinder.record_inserted_table self, sql
         super


### PR DESCRIPTION
6cfcbf965ad5d65c37640b12e6aa7c4cf07d1dcd in 0.9.3, LoadError occurred without Rails.

```
NameError:
  uninitialized constant DatabaseRewinder::InsertRecorder::Rails
# ./vendor/bundle/ruby/2.6.0/gems/database_rewinder-0.9.3/lib/database_rewinder/active_record_monkey.rb:10:in `<module:InsertRecorder>'
# ./vendor/bundle/ruby/2.6.0/gems/database_rewinder-0.9.3/lib/database_rewinder/active_record_monkey.rb:4:in `<module:DatabaseRewinder>'
# ./vendor/bundle/ruby/2.6.0/gems/database_rewinder-0.9.3/lib/database_rewinder/active_record_monkey.rb:3:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/database_rewinder-0.9.3/lib/database_rewinder.rb:102:in `require_relative'
# ./vendor/bundle/ruby/2.6.0/gems/database_rewinder-0.9.3/lib/database_rewinder.rb:102:in `rescue in <top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/database_rewinder-0.9.3/lib/database_rewinder.rb:97:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/zeitwerk-2.3.0/lib/zeitwerk/kernel.rb:23:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/zeitwerk-2.3.0/lib/zeitwerk/kernel.rb:23:in `require'
...
```