### PR TITLE
Use `use_transactional_tests` consistently on doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In cases of this situation, bundle database\_rewinder and add the following conf
 
 ```ruby
 RSpec.configure do |config|
-  config.use_transactional_examples = false
+  config.use_transactional_tests = false
 
   ...
 end


### PR DESCRIPTION
Currently, only the code block on README.md mentions `use_transactional_examples`.

I made it consistent with the other documents.

c.f.
https://github.com/amatsuda/database_rewinder/blob/f3701a54a90cf7a7fcffeffac63e4db16da541bc/README.md#mysql--use_transactional_tests-specific-problems