### PR TITLE
Add support for Rails 6.1 (another version)

### DIFF
--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'test-unit-rails'
-  spec.add_development_dependency 'rails', '~> 6.0', '<= 6.0.3.6' # , '~> 6.1'
+  spec.add_development_dependency 'rails'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pg'

--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'test-unit-rails'
-  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'rails', '~> 6.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pg'

--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pg'
+  spec.add_development_dependency 'selenium-webdriver'
   spec.required_ruby_version = '>= 2.0.0'
 end

--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'test-unit-rails'
-  spec.add_development_dependency 'rails', '~> 6.1'
+  spec.add_development_dependency 'rails', '~> 6.0', '<= 6.0.3.6' # , '~> 6.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pg'

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -16,7 +16,7 @@ module DatabaseRewinder
     end
 
     def create_cleaner(connection_name)
-      config = database_configuration[connection_name] or raise %Q[Database configuration named "#{connection_name}" is not configured.]
+      config = database_configuration.configs_for(env_name: connection_name, name: 'primary') or raise %Q[Database configuration named "#{connection_name}" is not configured.]
 
       Cleaner.new(config: config, connection_name: connection_name, only: @only, except: @except).tap {|c| @cleaners << c}
     end

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -16,7 +16,7 @@ module DatabaseRewinder
     end
 
     def create_cleaner(connection_name)
-      config = database_configuration.configs_for(env_name: connection_name, name: 'primary') or raise %Q[Database configuration named "#{connection_name}" is not configured.]
+      config = database_configuration.configs_for(env_name: connection_name).first or raise %Q[Database configuration named "#{connection_name}" is not configured.]
 
       Cleaner.new(config: config, connection_name: connection_name, only: @only, except: @except).tap {|c| @cleaners << c}
     end

--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -16,7 +16,7 @@ module DatabaseRewinder
     end
 
     def create_cleaner(connection_name)
-      config = database_configuration.respond_to?(:configs_for) ? database_configuration.configs_for(env_name: connection_name).first : database_configuration[connection_name] 
+      config = database_configuration.respond_to?(:configs_for) ? database_configuration.configs_for(env_name: connection_name).first : database_configuration[connection_name]
       config or raise %Q[Database configuration named "#{connection_name}" is not configured.]
 
       Cleaner.new(config: config, connection_name: connection_name, only: @only, except: @except).tap {|c| @cleaners << c}

--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -14,7 +14,7 @@ module DatabaseRewinder
     end
 
     def db
-      config.database
+      config.respond_to?(:database) ? config.database : config['database']
     end
 
     def clean(multiple: true)

--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -14,7 +14,13 @@ module DatabaseRewinder
     end
 
     def db
-      config.respond_to?(:database) ? config.database : config['database']
+      if config.respond_to?(:database)
+        config.database
+      elsif config.respond_to?(:config)
+        config.config['database']
+      else
+        config['database']
+      end
     end
 
     def clean(multiple: true)

--- a/lib/database_rewinder/cleaner.rb
+++ b/lib/database_rewinder/cleaner.rb
@@ -14,7 +14,7 @@ module DatabaseRewinder
     end
 
     def db
-      config['database']
+      config.database
     end
 
     def clean(multiple: true)


### PR DESCRIPTION
This is another version PR of https://github.com/amatsuda/database_rewinder/pull/77

If we prefer https://github.com/amatsuda/database_rewinder/pull/77, please close this PR.

To resolve #75, this PR fixes some errors and warnings caused from Rails 6.1. Roughly the same with #70.

> DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for)

> DEPRECATION WARNING: DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys

Note:
- On Rails 6.1 environment, we need to add selenium-webdriver gem
- We success to `bundle exec rake test` on both of Rails 6.0 / 6.1 environment.