### PR TITLE
Support multiple database configurations

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -92,7 +92,7 @@ module DatabaseRewinder
 
     def configuration_hash_for(connection_name)
       if database_configuration.respond_to?(:configs_for)
-        hash_config = database_configuration.configs_for(env_name: connection_name).first
+        hash_config = database_configuration_for(connection_name)
         if hash_config
           if hash_config.respond_to?(:configuration_hash)
             hash_config.configuration_hash.stringify_keys
@@ -102,6 +102,22 @@ module DatabaseRewinder
         end
       else
         database_configuration[connection_name]
+      end
+    end
+
+    def database_configuration_for(connection_name)
+      traditional_configuration_for(connection_name) || multiple_database_configuration_for(connection_name)
+    end
+
+    def traditional_configuration_for(connection_name)
+      database_configuration.configs_for(env_name: connection_name).first
+    end
+
+    def multiple_database_configuration_for(connection_name)
+      if ActiveRecord::VERSION::STRING >= '6.1'
+        database_configuration.configs_for(name: connection_name)
+      else
+        database_configuration.configs_for(spec_name: connection_name)
       end
     end
   end

--- a/test/database_rewinder_test.rb
+++ b/test/database_rewinder_test.rb
@@ -68,6 +68,29 @@ class DatabaseRewinder::DatabaseRewinderTest < ActiveSupport::TestCase
             end
           end
         end
+
+        sub_test_case 'with multiple database configurations' do
+          test 'simply giving a connection name only' do
+            assert_cleaners_added ['aaa'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'test' => {'aaa' => {'adapter' => 'sqlite3', 'database' => ':memory:'}}})
+              DatabaseRewinder['aaa']
+            end
+          end
+
+          test 'giving a connection name via Hash with :connection key' do
+            assert_cleaners_added ['bbb'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'test' => {'bbb' => {'adapter' => 'sqlite3', 'database' => ':memory:'}}})
+              DatabaseRewinder[connection: 'bbb']
+            end
+          end
+
+          test 'the Cleaner compatible syntax' do
+            assert_cleaners_added ['ccc'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'test' => {'ccc' => {'adapter' => 'sqlite3', 'database' => ':memory:'}}})
+              DatabaseRewinder[:aho, connection: 'ccc']
+            end
+          end
+        end
       end
     end
 

--- a/test/database_rewinder_test.rb
+++ b/test/database_rewinder_test.rb
@@ -44,6 +44,31 @@ class DatabaseRewinder::DatabaseRewinderTest < ActiveSupport::TestCase
           DatabaseRewinder[:aho, connection: 'ccc']
         end
       end
+
+      if ActiveRecord::VERSION::STRING >= '6'
+        sub_test_case 'with traditional configurations' do
+          test 'simply giving a connection name only' do
+            assert_cleaners_added ['aaa'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'aaa' => {'adapter' => 'sqlite3', 'database' => ':memory:'}})
+              DatabaseRewinder['aaa']
+            end
+          end
+
+          test 'giving a connection name via Hash with :connection key' do
+            assert_cleaners_added ['bbb'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'bbb' => {'adapter' => 'sqlite3', 'database' => ':memory:'}})
+              DatabaseRewinder[connection: 'bbb']
+            end
+          end
+
+          test 'the Cleaner compatible syntax' do
+            assert_cleaners_added ['ccc'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'ccc' => {'adapter' => 'sqlite3', 'database' => ':memory:'}})
+              DatabaseRewinder[:aho, connection: 'ccc']
+            end
+          end
+        end
+      end
     end
 
     test 'for connecting to multiple databases' do


### PR DESCRIPTION
v0.9.5 is supported Rails6.1 with #77 .
However, as reported in https://github.com/amatsuda/database_rewinder/pull/77#issuecomment-832080880, the DB configurations cannot be obtained in the following formats.
```
production:
  primary:
    database: my_primary_database
    user: root
    adapter: mysql
  primary_replica:
    database: my_primary_database
    user: root_readonly
    adapter: mysql
    replica: true
  animals:
    database: my_animals_database
    user: animals_root
    adapter: mysql
    migrations_paths: db/animals_migrate
  animals_replica:
    database: my_animals_database
    user: animals_readonly
    adapter: mysql
    replica: true
```
Referenced from https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application

This PR resolves the problem of configuring multiple DBs.