### PR TITLE
Fix [] with dealing with multiple database.

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -22,7 +22,7 @@ module DatabaseRewinder
     end
 
     def [](connection)
-      @cleaners.detect {|c| c.connection_name == connection} || create_cleaner(connection)
+      @cleaners&.detect {|c| c.connection_name == connection} || create_cleaner(connection)
     end
 
     def all=(v)


### PR DESCRIPTION
When we follow [Dealing with mulitple DBs](https://github.com/amatsuda/database_rewinder#dealing-with-multiple-dbs), an error will occur.
```shell
Failure/Error: DatabaseRewinder["test"]

NoMethodError:
  undefined method `detect' for nil:NilClass
```

I changed the code to ensure that `create_cleaner` is called when using multiple databases.


