### PR TITLE
fix: use Rails.application.deprecators.silence

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -75,7 +75,12 @@ module DatabaseRewinder
     def all_table_names(connection)
       cache_key = get_cache_key(connection.pool)
       #NOTE connection.tables warns on AR 5 with some adapters
-      tables = ActiveSupport::Deprecation.silence { connection.tables }
+      tables =
+        if Rails.application.respond_to?(:deprecators) # AR >= 7.1
+          Rails.application.deprecators.silence { connection.tables }
+        else
+          ActiveSupport::Deprecation.silence { connection.tables }
+        end
       schema_migraion_table_name =
         if ActiveRecord::SchemaMigration.respond_to?(:table_name)
           ActiveRecord::SchemaMigration.table_name


### PR DESCRIPTION
ActiveSupport::Deprecation.silence has been deprecated since Rails version 7.1 and above,

```
DEPRECATION WARNING: Calling silence on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use Rails.application.deprecators.silence instead)
```

So if you have deprecators in Rails.application, make sure it is 7.1 or higher and use `Rails.application.deprecators.silence`. Otherwise, the process is the same as before.