### PR TITLE
Remove deprecation silence for connection.tables

### DIFF
--- a/lib/database_rewinder.rb
+++ b/lib/database_rewinder.rb
@@ -78,10 +78,10 @@ module DatabaseRewinder
       cache_key = get_cache_key(connection.pool)
       #NOTE connection.tables warns on AR 5 with some adapters
       tables =
-        if Rails.application.respond_to?(:deprecators) # AR >= 7.1
-          Rails.application.deprecators.silence { connection.tables }
-        else
+        if ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR == 0
           ActiveSupport::Deprecation.silence { connection.tables }
+        else
+          connection.tables
         end
       schema_migraion_table_name =
         if ActiveRecord::SchemaMigration.respond_to?(:table_name)


### PR DESCRIPTION
AR 5.0 introduced a warning, removed in AR 5.1.

introduced: https://github.com/rails/rails/commit/7429633b82
removed: https://github.com/rails/rails/commit/5973a984c3

---

While using database_rewinder in a non-Rails project, I encountered the following error.

```
NameError:
  uninitialized constant #<Class:DatabaseRewinder>::Rails
```

In trying to resolve this error, I realized that deprecation warning is no longer present.

This error has been occurring since v1.0.0. See: #86
