### PR TITLE
What about hidden databases?

### DIFF
--- a/test/database_rewinder_test.rb
+++ b/test/database_rewinder_test.rb
@@ -92,6 +92,24 @@ class DatabaseRewinder::DatabaseRewinderTest < ActiveSupport::TestCase
           end
         end
       end
+
+      if ActiveRecord::VERSION::MAJOR >= 7
+        sub_test_case 'when dealing with hidden databases' do
+          test 'configuring via database_tasks' do
+            assert_cleaners_added ['aaa'] do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'aaa' => {'adapter' => 'sqlite3', 'database' => ':memory:', 'database_tasks' => false}})
+              DatabaseRewinder['aaa']
+            end
+          end
+
+          test 'configuring via replica' do
+            assert_raises(RuntimeError, 'Database configuration named "bbb" is not configured.') do
+              DatabaseRewinder.database_configuration = ActiveRecord::DatabaseConfigurations.new({'bbb' => {'adapter' => 'sqlite3', 'database' => ':memory:', 'replica' => true}})
+              DatabaseRewinder['bbb']
+            end
+          end
+        end
+      end
     end
 
     test 'for connecting to multiple databases' do


### PR DESCRIPTION
`ActiveRecord::Base.configurations.configs_for` ([Rails 7.0](https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/activerecord/lib/active_record/database_configurations.rb#L98), [Rails 7.1](https://github.com/rails/rails/blob/fc734f28e65ef8829a1a939ee6702c1f349a1d5a/activerecord/lib/active_record/database_configurations.rb#L45)) knows two kind of hidden database configurations: `replica: true` and `database_tasks: false`. 

It was unexpected for me to find out that `DatabaseRewinder` doesn't consider the readonly database I have in my project. Because when testing I still insert fakes and expect them to be rewinded.

I added to tests to the suite to pinpoint the problem. But I'm not sure what a good solution would actually be. Maybe a hint in the docs about how `database_tasks: false` will affect your upgrade path to Rails 7 when using `DatabaseRewinder` would be enough?