### PR TITLE
Include minimum files in packed gem

### DIFF
--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -14,9 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/amatsuda/database_rewinder'
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = Dir["MIT_LICENSE", "README.md", "lib/**/*"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler'

--- a/database_rewinder.gemspec
+++ b/database_rewinder.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/amatsuda/database_rewinder'
   spec.license       = "MIT"
 
-  spec.files         = Dir["MIT_LICENSE", "README.md", "lib/**/*"]
+  spec.files         = `git ls-files lib/ MIT_LICENSE README.md`.split
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This aims to reduce the gem size by excluding unneeded files like test files, CI files, etc.
Note that `test_files` in a gemspec is no longer supported.

Gem size diff:

```sh-session
$ du -h database_rewinder-1.0.1.gem*
 12K	database_rewinder-1.0.1.gem
 16K	database_rewinder-1.0.1.gem.old
```

Newly included files in the gem:

```sh-session
$ tree -aF database_rewinder-1.0.1
database_rewinder-1.0.1/
├── MIT_LICENSE
├── README.md
└── lib/
    ├── database_rewinder/
    │   ├── active_record_monkey.rb
    │   ├── cleaner.rb
    │   ├── compatibility.rb
    │   ├── dummy_model.rb
    │   ├── multiple_statements_executor.rb
    │   └── railtie.rb
    └── database_rewinder.rb

3 directories, 9 files
```
